### PR TITLE
Divide cars model into simpler models 

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,8 @@ import authRouter from "./routes/auth.router.js";
 import carRouter from "./routes/car.router.js";
 import leadRouter from "./routes/lead.router.js";
 import makeRouter from "./routes/make.router.js";
+import modelRouter from "./routes/model.router.js";
+import packageRouter from "./routes/package.router.js";
 
 //config + variables
 const app = express();
@@ -21,6 +23,8 @@ app.use("/api/cars", carRouter);
 app.use("/api/leads", leadRouter);
 app.use("/api/auth", authRouter);
 app.use("/api/makes", makeRouter);
+app.use("/api/models", modelRouter);
+app.use("/api/packages" , packageRouter);
 
 // fallback
 app.use((req, res) => {

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,5 @@
 // packages
 import express from "express";
-import dotenv from "dotenv";
 import cors from "cors";
 
 // routers

--- a/src/app.js
+++ b/src/app.js
@@ -1,22 +1,26 @@
 // packages
 import express from "express";
 import dotenv from "dotenv";
-import cors from 'cors';
+import cors from "cors";
 
 // routers
 import userRouter from "./routes/user.router.js";
 import authRouter from "./routes/auth.router.js";
 import carRouter from "./routes/car.router.js";
 import leadRouter from "./routes/lead.router.js";
+import makeRouter from "./routes/make.router.js";
+
 //config + variables
 const app = express();
-app.use(express.json({ limit: '10mb' }));
+app.use(express.json({ limit: "10mb" }));
 app.use(cors());
+
 // api endpoints
 app.use("/api/users", userRouter);
 app.use("/api/cars", carRouter);
-app.use("/api/leads" , leadRouter);
+app.use("/api/leads", leadRouter);
 app.use("/api/auth", authRouter);
+app.use("/api/makes", makeRouter);
 
 // fallback
 app.use((req, res) => {

--- a/src/config/envVariables.js
+++ b/src/config/envVariables.js
@@ -4,4 +4,6 @@ dotenv.config();
 export const PORT = process.env.PORT;
 export const DATABASE_URL = process.env.DATABASE_URL;
 export const SECRET_KEY = process.env.SECRET_KEY;
+export const MAIL = process.env.MAIL;
+export const MAIL_PASSWORD = process.env.MAIL_PASSWORD;
  

--- a/src/controllers/car.controller.js
+++ b/src/controllers/car.controller.js
@@ -15,7 +15,7 @@ export const carController = {
       const { cars, currentPage, totalPages } =
         await carServices.getPaginated(req);
       return res
-        .status(201)
+        .status(200)
         .json({
           result: "successfully got paginated cars",
           currentPage: currentPage,
@@ -32,16 +32,6 @@ export const carController = {
       return res
         .status(201)
         .json({ result: "successfully created car", car: car });
-    } catch (error) {
-      return res.status(500).json({ result: "error", message: error.message });
-    }
-  },
-  getMakes: async (req, res) => {
-    try {
-      const makes = await carServices.getMakes();
-      return res
-        .status(200)
-        .json({ result: "successfully got makes", makes: makes });
     } catch (error) {
       return res.status(500).json({ result: "error", message: error.message });
     }

--- a/src/controllers/make.controller.js
+++ b/src/controllers/make.controller.js
@@ -1,0 +1,47 @@
+import { makeServices } from "../services/make.services.js";
+export const makeController = {
+  get: async (req, res) => {
+    try {
+      const makes = await makeServices.get();
+      return res
+        .status(200)
+        .json({ result: "successfully got makes", makes: makes });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+  create: async (req, res) => {
+    try {
+      const make = await makeServices.create(req.body);
+      return res
+        .status(201)
+        .json({ result: "successfully created make", make: make });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+  getMakeById: async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const make = await makeServices.getMakeById(id);
+      if (make == null)
+        return res.status(404).json({ result: "make Doesn't exist" });
+      return res
+        .status(200)
+        .json({ result: "successfully got make", make: make });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+  delete: async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const make = await makeServices.delete(id);
+      return res
+        .status(200)
+        .json({ result: "successfully deleted make", make: make });
+    } catch (error) {
+      res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+};

--- a/src/controllers/model.controller.js
+++ b/src/controllers/model.controller.js
@@ -22,6 +22,17 @@ export const modelController = {
       return res.status(500).json({ result: "error", message: error.message });
     }
   },
+  filter: async (req, res) => {
+    try {
+      const filter = req.query;
+      const models = await modelServices.filter(filter);
+      return res
+        .status(200)
+        .json({ result: "successfully got models", models: models });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
   getModelById: async (req, res) => {
     try {
       const id = parseInt(req.params.id);

--- a/src/controllers/model.controller.js
+++ b/src/controllers/model.controller.js
@@ -1,0 +1,49 @@
+// model.controller.js
+import { modelServices } from "../services/model.services.js";
+
+export const modelController = {
+  get: async (req, res) => {
+    try {
+      const models = await modelServices.get();
+      return res
+        .status(200)
+        .json({ result: "successfully got models", models: models });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+  create: async (req, res) => {
+    try {
+      const model = await modelServices.create(req.body);
+      return res
+        .status(201)
+        .json({ result: "successfully created model", model: model });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+  getModelById: async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const model = await modelServices.getModelById(id);
+      if (model == null)
+        return res.status(404).json({ result: "model doesn't exist" });
+      return res
+        .status(200)
+        .json({ result: "successfully got model", model: model });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+  delete: async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const model = await modelServices.delete(id);
+      return res
+        .status(200)
+        .json({ result: "successfully deleted model", model: model });
+    } catch (error) {
+      res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+};

--- a/src/controllers/package.controller.js
+++ b/src/controllers/package.controller.js
@@ -22,15 +22,13 @@ export const packageController = {
       return res.status(500).json({ result: "error", message: error.message });
     }
   },
-  getPackageById: async (req, res) => {
+  filter: async (req, res) => {
     try {
-      const id = parseInt(req.params.id);
-      const pkg = await packageServices.getPackageById(id);
-      if (pkg == null)
-        return res.status(404).json({ result: "package doesn't exist" });
+      const filter = req.query;
+      const packages = await packageServices.filter(filter);
       return res
         .status(200)
-        .json({ result: "successfully got package", package: pkg });
+        .json({ result: "successfully got packages", packages: packages });
     } catch (error) {
       return res.status(500).json({ result: "error", message: error.message });
     }

--- a/src/controllers/package.controller.js
+++ b/src/controllers/package.controller.js
@@ -1,0 +1,49 @@
+// package.controller.js
+import { packageServices } from "../services/package.services.js";
+
+export const packageController = {
+  get: async (req, res) => {
+    try {
+      const packages = await packageServices.get();
+      return res
+        .status(200)
+        .json({ result: "successfully got packages", packages: packages });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+  create: async (req, res) => {
+    try {
+      const pkg = await packageServices.create(req.body);
+      return res
+        .status(201)
+        .json({ result: "successfully created package", package: pkg });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+  getPackageById: async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const pkg = await packageServices.getPackageById(id);
+      if (pkg == null)
+        return res.status(404).json({ result: "package doesn't exist" });
+      return res
+        .status(200)
+        .json({ result: "successfully got package", package: pkg });
+    } catch (error) {
+      return res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+  delete: async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      const pkg = await packageServices.delete(id);
+      return res
+        .status(200)
+        .json({ result: "successfully deleted package", package: pkg });
+    } catch (error) {
+      res.status(500).json({ result: "error", message: error.message });
+    }
+  },
+};

--- a/src/helpers/processCarQuery.js
+++ b/src/helpers/processCarQuery.js
@@ -1,0 +1,122 @@
+export const processCarQuery = (q) => {
+  const query = { where: {}, orderBy: {} };
+  query.page = q.page || 1;
+  query.limit = q.limit || 10;
+  query.orderBy[q.sort || "price"] = q.order || "asc";
+  q.id ? (query.where.id = parseInt(q.id)) : null;
+  q.makeId ? (query.where.makeId = parseInt(q.makeId)) : null;
+  q.modelId ? (query.where.modelId = parseInt(q.modelId)) : null;
+  q.packageId ? (query.where.packageId = parseInt(q.packageId)) : null;
+  q.price ? (query.where.price = parseInt(q.price)) : null;
+  q.fuel ? (query.where.fuel = q.fuel) : null;
+  q.transmissionType
+    ? (query.where.transmissionType = q.transmissionType)
+    : null;
+  q.steeringPosition
+    ? (query.where.steeringPosition = q.steeringPosition)
+    : null;
+  q.location ? (query.where.location = q.location) : null;
+  q.driveType ? (query.where.driveType = q.driveType) : null;
+  q.manufactureDate
+    ? (query.where.manufactureDate = new Date(q.manufactureDate))
+    : null;
+  setDates(query, q);
+
+  q.minEngineSize
+    ? (query.where.engineSize = { gte: parseInt(q.minEngineSize) })
+    : null;
+  q.maxEngineSize
+    ? (query.where.engineSize = { lte: parseInt(q.maxEngineSize) })
+    : null;
+  q.minYear ? (query.where.year = { gte: parseInt(q.minYear) }) : null;
+  q.maxYear ? (query.where.year = { lte: parseInt(q.maxYear) }) : null;
+
+  if (q.minMileage || q.maxMileage) {
+    query.where.mileage = {};
+    if (q.minMileage) {
+      query.where.mileage.gte = parseInt(q.minMileage);
+    }
+    if (q.maxMileage) {
+      query.where.mileage.lte = parseInt(q.maxMileage);
+    }
+  }
+
+  if (q.minPrice || q.maxPrice) {
+    query.where.price = {};
+    if (q.minPrice) {
+      query.where.price.gte = parseInt(q.minPrice);
+    }
+    if (q.maxPrice) {
+      query.where.price.lte = parseInt(q.maxPrice);
+    }
+  }
+
+  return query;
+};
+
+const setDates = (query, q) => {
+  if (q.registrationDate) {
+    const dateParts = q.registrationDate.split("-");
+    const year = parseInt(dateParts[2]);
+    const month = parseInt(dateParts[1]) - 1; // Months are zero-based in JavaScript
+    const day = parseInt(dateParts[0]);
+
+    const startDate = new Date(year, month, day);
+    const endDate = new Date(year, month, day + 1); // Assuming you want to search within the specified date only
+
+    query.where.registrationDate = { gte: startDate, lt: endDate };
+  }
+  if (q.minRegistrationDate || q.maxRegistrationDate) {
+    query.where.registrationDate = {};
+    if (q.minRegistrationDate) {
+      const minDateParts = q.minRegistrationDate.split("-");
+      const minYear = parseInt(minDateParts[2]);
+      const minMonth = parseInt(minDateParts[1]) - 1;
+      const minDay = parseInt(minDateParts[0]);
+      const minDate = new Date(minYear, minMonth, minDay);
+      query.where.registrationDate.gte = minDate;
+    }
+    if (q.maxRegistrationDate) {
+      const maxDateParts = q.maxRegistrationDate.split("-");
+      const maxYear = parseInt(maxDateParts[2]);
+      const maxMonth = parseInt(maxDateParts[1]) - 1;
+      const maxDay = parseInt(maxDateParts[0]);
+      const maxDate = new Date(maxYear, maxMonth, maxDay + 1);
+      query.where.registrationDate.lt = maxDate;
+    }
+  }
+
+  if (q.manufactureDate) {
+    const dateParts = q.manufactureDate.split("-");
+    const year = parseInt(dateParts[2]);
+    const month = parseInt(dateParts[1]) - 1; // Months are zero-based in JavaScript
+    const day = parseInt(dateParts[0]);
+
+    const startDate = new Date(year, month, day);
+    const endDate = new Date(year, month, day + 1); // Assuming you want to search within the specified date only
+
+    query.where.manufactureDate = { gte: startDate, lt: endDate };
+  }
+
+  if (q.minManufactureDate || q.maxManufactureDate) {
+    query.where.manufactureDate = {};
+
+    if (q.minManufactureDate) {
+      const minDateParts = q.minManufactureDate.split("-");
+      const minYear = parseInt(minDateParts[2]);
+      const minMonth = parseInt(minDateParts[1]) - 1;
+      const minDay = parseInt(minDateParts[0]);
+      const minDate = new Date(minYear, minMonth, minDay);
+      query.where.manufactureDate.gte = minDate;
+    }
+
+    if (q.maxManufactureDate) {
+      const maxDateParts = q.maxManufactureDate.split("-");
+      const maxYear = parseInt(maxDateParts[2]);
+      const maxMonth = parseInt(maxDateParts[1]) - 1;
+      const maxDay = parseInt(maxDateParts[0]);
+      const maxDate = new Date(maxYear, maxMonth, maxDay + 1);
+      query.where.manufactureDate.lt = maxDate;
+    }
+  }
+};

--- a/src/helpers/processCarQuery.js
+++ b/src/helpers/processCarQuery.js
@@ -17,20 +17,14 @@ export const processCarQuery = (q) => {
     : null;
   q.location ? (query.where.location = q.location) : null;
   q.driveType ? (query.where.driveType = q.driveType) : null;
+  q.engineCC ? (query.where.engineCC = parseInt(q.engineCC)) : null;
   q.manufactureDate
     ? (query.where.manufactureDate = new Date(q.manufactureDate))
     : null;
   setDates(query, q);
 
-  q.minEngineSize
-    ? (query.where.engineSize = { gte: parseInt(q.minEngineSize) })
-    : null;
-  q.maxEngineSize
-    ? (query.where.engineSize = { lte: parseInt(q.maxEngineSize) })
-    : null;
-  q.minYear ? (query.where.year = { gte: parseInt(q.minYear) }) : null;
-  q.maxYear ? (query.where.year = { lte: parseInt(q.maxYear) }) : null;
 
+  
   if (q.minMileage || q.maxMileage) {
     query.where.mileage = {};
     if (q.minMileage) {
@@ -38,6 +32,17 @@ export const processCarQuery = (q) => {
     }
     if (q.maxMileage) {
       query.where.mileage.lte = parseInt(q.maxMileage);
+    }
+  }
+
+  // for engineCC min and max
+  if (q.minEngineCC || q.maxEngineCC) {
+    query.where.engineCC = {};
+    if (q.minEngineCC) {
+      query.where.engineCC.gte = parseInt(q.minEngineCC);
+    }
+    if (q.maxEngineCC) {
+      query.where.engineCC.lte = parseInt(q.maxEngineCC);
     }
   }
 
@@ -57,9 +62,9 @@ export const processCarQuery = (q) => {
 const setDates = (query, q) => {
   if (q.registrationDate) {
     const dateParts = q.registrationDate.split("-");
-    const year = parseInt(dateParts[2]);
-    const month = parseInt(dateParts[1]) - 1; // Months are zero-based in JavaScript
-    const day = parseInt(dateParts[0]);
+    const year = parseInt(dateParts[0]);
+    const month = parseInt(dateParts[1]) - 1; 
+    const day = parseInt(dateParts[2]);
 
     const startDate = new Date(year, month, day);
     const endDate = new Date(year, month, day + 1); // Assuming you want to search within the specified date only
@@ -70,17 +75,17 @@ const setDates = (query, q) => {
     query.where.registrationDate = {};
     if (q.minRegistrationDate) {
       const minDateParts = q.minRegistrationDate.split("-");
-      const minYear = parseInt(minDateParts[2]);
+      const minYear = parseInt(minDateParts[0]);
       const minMonth = parseInt(minDateParts[1]) - 1;
-      const minDay = parseInt(minDateParts[0]);
+      const minDay = parseInt(minDateParts[2]);
       const minDate = new Date(minYear, minMonth, minDay);
       query.where.registrationDate.gte = minDate;
     }
     if (q.maxRegistrationDate) {
       const maxDateParts = q.maxRegistrationDate.split("-");
-      const maxYear = parseInt(maxDateParts[2]);
+      const maxYear = parseInt(maxDateParts[0]);
       const maxMonth = parseInt(maxDateParts[1]) - 1;
-      const maxDay = parseInt(maxDateParts[0]);
+      const maxDay = parseInt(maxDateParts[2]);
       const maxDate = new Date(maxYear, maxMonth, maxDay + 1);
       query.where.registrationDate.lt = maxDate;
     }
@@ -88,9 +93,9 @@ const setDates = (query, q) => {
 
   if (q.manufactureDate) {
     const dateParts = q.manufactureDate.split("-");
-    const year = parseInt(dateParts[2]);
-    const month = parseInt(dateParts[1]) - 1; // Months are zero-based in JavaScript
-    const day = parseInt(dateParts[0]);
+    const year = parseInt(dateParts[0]);
+    const month = parseInt(dateParts[1]) - 1; 
+    const day = parseInt(dateParts[2]);
 
     const startDate = new Date(year, month, day);
     const endDate = new Date(year, month, day + 1); // Assuming you want to search within the specified date only
@@ -103,18 +108,18 @@ const setDates = (query, q) => {
 
     if (q.minManufactureDate) {
       const minDateParts = q.minManufactureDate.split("-");
-      const minYear = parseInt(minDateParts[2]);
+      const minYear = parseInt(minDateParts[0]);
       const minMonth = parseInt(minDateParts[1]) - 1;
-      const minDay = parseInt(minDateParts[0]);
+      const minDay = parseInt(minDateParts[2]);
       const minDate = new Date(minYear, minMonth, minDay);
       query.where.manufactureDate.gte = minDate;
     }
 
     if (q.maxManufactureDate) {
       const maxDateParts = q.maxManufactureDate.split("-");
-      const maxYear = parseInt(maxDateParts[2]);
+      const maxYear = parseInt(maxDateParts[0]);
       const maxMonth = parseInt(maxDateParts[1]) - 1;
-      const maxDay = parseInt(maxDateParts[0]);
+      const maxDay = parseInt(maxDateParts[2]);
       const maxDate = new Date(maxYear, maxMonth, maxDay + 1);
       query.where.manufactureDate.lt = maxDate;
     }

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -1,5 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
 generator client {
   provider = "prisma-client-js"
 }
@@ -18,26 +16,57 @@ model User {
   createdAt DateTime @default(now())
 }
 
+model Make {
+  id        Int       @id @default(autoincrement())
+  name      String    @unique
+  createdAt DateTime  @default(now())
+  Model     Model[]
+  Package   Package[]
+  Car       Car[]
+}
+
+model Model {
+  id        Int       @id @default(autoincrement())
+  name      String    @unique
+  make      Make      @relation(fields: [makeId], references: [id])
+  makeId    Int
+  createdAt DateTime  @default(now())
+  Package   Package[]
+  Car       Car[]
+}
+
+model Package {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  make      Make     @relation(fields: [makeId], references: [id])
+  makeId    Int
+  model     Model    @relation(fields: [modelId], references: [id])
+  modelId   Int
+  createdAt DateTime @default(now())
+  Car       Car[]
+}
+
 model Car {
-  id           Int     @id @default(autoincrement())
-  make         String
-  model        String
-  year         Int
-  mileage      Int
-  engineCC     String
-  steering     String
-  transmission String
-  driveTrain   String
-  fuel         String
-  package      String
-  priceRange   String
-  chassisCode  String
-  leads        Lead[]
-  image1       Bytes    @db.LongBlob
-  image2       Bytes?   @db.LongBlob
-  image3       Bytes?   @db.LongBlob
-  image4       Bytes?   @db.LongBlob
-  image5       Bytes?   @db.LongBlob
+  id               Int      @id @default(autoincrement())
+  make             Make     @relation(fields: [makeId], references: [id])
+  makeId           Int
+  model            Model    @relation(fields: [modelId], references: [id])
+  modelId          Int
+  year             Int
+  fuel             String
+  priceRange       String
+  package          Package? @relation(fields: [packageId], references: [id])
+  packageId        Int?
+  manufactureDate  DateTime
+  registrationDate DateTime
+  chassisCode      String
+  leads            Lead[]
+  createdAt        DateTime @default(now())
+  image1           Bytes    @db.LongBlob
+  image2           Bytes?   @db.LongBlob
+  image3           Bytes?   @db.LongBlob
+  image4           Bytes?   @db.LongBlob
+  image5           Bytes?   @db.LongBlob
 }
 
 model Lead {
@@ -48,7 +77,9 @@ model Lead {
   message   String?
   contacted Boolean  @default(false)
   timestamp DateTime @default(now())
-  Car       Car?     @relation(fields: [carId], references: [id])
+  country   String?
+  address   String?
+  city      String?
+  car       Car?     @relation(fields: [carId], references: [id])
   carId     Int?
-
 }

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -67,8 +67,8 @@ model Car {
   manufactureDate  DateTime
   registrationDate DateTime
   chassisCode      String
-  status           String
-  category         String
+  status           String   @default("available")
+  category         String   @default("newArrival")
   createdAt        DateTime @default(now())
   image1           Bytes    @db.LongBlob
   image2           Bytes?   @db.LongBlob

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -52,6 +52,8 @@ model Car {
   makeId           Int
   model            Model    @relation(fields: [modelId], references: [id])
   modelId          Int
+  package          Package? @relation(fields: [packageId], references: [id])
+  packageId        Int?
   year             Int
   fuel             String
   mileage          Int
@@ -62,18 +64,18 @@ model Car {
   steeringPosition String
   location         String
   price            Int
-  package          Package? @relation(fields: [packageId], references: [id])
-  packageId        Int?
   manufactureDate  DateTime
   registrationDate DateTime
   chassisCode      String
-  leads            Lead[]
+  status           String
+  category         String
   createdAt        DateTime @default(now())
   image1           Bytes    @db.LongBlob
   image2           Bytes?   @db.LongBlob
   image3           Bytes?   @db.LongBlob
   image4           Bytes?   @db.LongBlob
   image5           Bytes?   @db.LongBlob
+  leads            Lead[]
 }
 
 model Lead {

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -54,7 +54,14 @@ model Car {
   modelId          Int
   year             Int
   fuel             String
-  priceRange       String
+  mileage          Int
+  color            String
+  engineCC         Int
+  transmissionType String
+  driveType        String
+  steeringPosition String
+  location         String
+  price            Int
   package          Package? @relation(fields: [packageId], references: [id])
   packageId        Int?
   manufactureDate  DateTime

--- a/src/routes/car.router.js
+++ b/src/routes/car.router.js
@@ -5,7 +5,6 @@ const carRouter = Router();
 
 // will be used from client side that's why no middleware
 carRouter.get("/", carController.get);
-carRouter.get("/makes", carController.getMakes);
 carRouter.get("/paginated", carController.getPaginated);
 carRouter.get("/:id", carController.getCarById);
 

--- a/src/routes/make.router.js
+++ b/src/routes/make.router.js
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { makeController } from "../controllers/make.controller.js";
+import { confirmToken } from "../middlewares/confirmToken.middleware.js";
+
+const makeRouter = Router();
+
+makeRouter.get("/", makeController.get);
+makeRouter.post("/", makeController.create);
+makeRouter.get("/:id", makeController.getMakeById);
+makeRouter.delete("/:id", makeController.delete);
+
+
+export default makeRouter;

--- a/src/routes/make.router.js
+++ b/src/routes/make.router.js
@@ -3,10 +3,10 @@ import { makeController } from "../controllers/make.controller.js";
 import { confirmToken } from "../middlewares/confirmToken.middleware.js";
 
 const makeRouter = Router();
-
 makeRouter.get("/", makeController.get);
-makeRouter.post("/", makeController.create);
 makeRouter.get("/:id", makeController.getMakeById);
+makeRouter.use(confirmToken);
+makeRouter.post("/", makeController.create);
 makeRouter.delete("/:id", makeController.delete);
 
 

--- a/src/routes/model.router.js
+++ b/src/routes/model.router.js
@@ -1,0 +1,13 @@
+// models.routes.js
+import { Router } from "express";
+import { modelController } from "../controllers/model.controller.js";
+import { confirmToken } from "../middlewares/confirmToken.middleware.js";
+
+const modelRouter = Router();
+modelRouter.get("/", modelController.get);
+modelRouter.get("/:id", modelController.getModelById);
+modelRouter.use(confirmToken);
+modelRouter.post("/", modelController.create);
+modelRouter.delete("/:id", modelController.delete);
+
+export default modelRouter;

--- a/src/routes/model.router.js
+++ b/src/routes/model.router.js
@@ -5,6 +5,7 @@ import { confirmToken } from "../middlewares/confirmToken.middleware.js";
 
 const modelRouter = Router();
 modelRouter.get("/", modelController.get);
+modelRouter.get("/filter", modelController.filter);
 modelRouter.get("/:id", modelController.getModelById);
 modelRouter.use(confirmToken);
 modelRouter.post("/", modelController.create);

--- a/src/routes/package.router.js
+++ b/src/routes/package.router.js
@@ -1,0 +1,15 @@
+// packages.routes.js
+import { Router } from "express";
+import { packageController } from "../controllers/package.controller.js";
+import { confirmToken } from "../middlewares/confirmToken.middleware.js";
+
+const packageRouter = Router();
+packageRouter.get("/", packageController.get);
+packageRouter.get("/:id", packageController.getPackageById);
+
+packageRouter.use(confirmToken);
+
+packageRouter.post("/", packageController.create);
+packageRouter.delete("/:id", packageController.delete);
+
+export default packageRouter;

--- a/src/routes/package.router.js
+++ b/src/routes/package.router.js
@@ -5,7 +5,7 @@ import { confirmToken } from "../middlewares/confirmToken.middleware.js";
 
 const packageRouter = Router();
 packageRouter.get("/", packageController.get);
-packageRouter.get("/:id", packageController.getPackageById);
+packageRouter.get("/filter", packageController.filter);
 
 packageRouter.use(confirmToken);
 

--- a/src/services/car.services.js
+++ b/src/services/car.services.js
@@ -40,7 +40,7 @@ export const carServices = {
           price: true,
           steeringPosition: true,
           transmissionType: true,
-          // image1: true,
+          image1: true,
           location: true,
           make: {
             select: {

--- a/src/services/car.services.js
+++ b/src/services/car.services.js
@@ -11,8 +11,8 @@ export const carServices = {
   },
   getPaginated: async (req) => {
     try {
-      const page = parseInt(req.query.page);
-      const limit = parseInt(req.query.limit);
+      const page = parseInt(req.query.page) || 1;
+      const limit = parseInt(req.query.limit) || 10;
       const skip = (page - 1) * limit;
       const totalCars = await prisma.car.count();
       const cars = await prisma.car.findMany({
@@ -20,13 +20,27 @@ export const carServices = {
         take: limit,
         select: {
           id: true,
-          make: true,
-          model: true,
-          year: true,
-          priceRange: true,
-          steering: true,
           mileage: true,
+          price: true,
+          steeringPosition: true,
+          transmissionType: true,
           image1: true,
+          location: true,
+          make: {
+            select: {
+              name: true,
+            },
+          },
+          model: {
+            select: {
+              name: true,
+            },
+          },
+          package: {
+            select: {
+              name: true,
+            },
+          },
         },
       });
 
@@ -42,6 +56,8 @@ export const carServices = {
   create: async (car) => {
     try {
       car = setCarImages(car);
+      car.registrationDate = new Date(car.registrationDate);
+      car.manufactureDate = new Date(car.manufactureDate);
       const result = await prisma.car.create({ data: car });
       return result;
     } catch (error) {

--- a/src/services/car.services.js
+++ b/src/services/car.services.js
@@ -1,5 +1,6 @@
 import prisma from "../utils/prisma.js";
 import { setCarImages } from "../helpers/setCarImages.js";
+import { processCarQuery } from "../helpers/processCarQuery.js";
 export const carServices = {
   get: async () => {
     try {
@@ -11,20 +12,35 @@ export const carServices = {
   },
   getPaginated: async (req) => {
     try {
-      const page = parseInt(req.query.page) || 1;
-      const limit = parseInt(req.query.limit) || 10;
+      const query = processCarQuery(req.query);
+      const page = parseInt(query.page) || 1;
+      const limit = parseInt(query.limit) || 10;
+      const where = query.where;
+      const order = query.orderBy;
       const skip = (page - 1) * limit;
-      const totalCars = await prisma.car.count();
+      console.log(query);
+      const totalCars = await prisma.car.count({
+        where: {
+          ...where,
+        },
+      });
+      console.log(query);
       const cars = await prisma.car.findMany({
         skip,
         take: limit,
+        orderBy: {
+          ...order,
+        },
+        where: {
+          ...where,
+        },
         select: {
           id: true,
           mileage: true,
           price: true,
           steeringPosition: true,
           transmissionType: true,
-          image1: true,
+          // image1: true,
           location: true,
           make: {
             select: {
@@ -70,19 +86,6 @@ export const carServices = {
         where: {
           id: id, // Replace with the actual ID of the car you want to find
         },
-      });
-      return result;
-    } catch (error) {
-      throw new Error(error.message);
-    }
-  },
-  getMakes: async () => {
-    try {
-      const result = await prisma.car.findMany({
-        select: {
-          make: true,
-        },
-        distinct: ["make"],
       });
       return result;
     } catch (error) {

--- a/src/services/make.services.js
+++ b/src/services/make.services.js
@@ -1,0 +1,44 @@
+import prisma from "../utils/prisma.js";
+export const makeServices = {
+  get: async () => {
+    try {
+      const makes = await prisma.make.findMany();
+      return makes;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+  create: async (make) => {
+    try {
+      const result = await prisma.make.create({ data: make });
+      return result;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+  getMakeById: async (id) => {
+    try {
+      const result = await prisma.make.findUnique({
+        where: {
+          id: id, // Replace with the actual ID of the make you want to find
+        },
+      });
+      return result;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+  delete: async (id) => {
+    try {
+      const result = await prisma.make.delete({
+        where: {
+          id: id,
+        },
+      });
+      return result;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+
+};

--- a/src/services/model.services.js
+++ b/src/services/model.services.js
@@ -26,6 +26,18 @@ export const modelServices = {
       throw new Error(error.message);
     }
   },
+  filter: async (filter) => {
+    try {
+      filter.makeId? filter.makeId = parseInt(filter.makeId): null;
+      const result = await prisma.model.findMany({
+        where: filter,
+      });
+      return result;
+    }
+    catch (error) {
+      throw new Error(error.message);
+    }
+  },
   getModelById: async (id) => {
     try {
       const result = await prisma.model.findUnique({

--- a/src/services/model.services.js
+++ b/src/services/model.services.js
@@ -1,0 +1,45 @@
+// model.services.js
+import prisma from "../utils/prisma.js";
+
+export const modelServices = {
+  get: async () => {
+    try {
+      const models = await prisma.model.findMany();
+      return models;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+  create: async (model) => {
+    try {
+      const result = await prisma.model.create({ data: model });
+      return result;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+  getModelById: async (id) => {
+    try {
+      const result = await prisma.model.findUnique({
+        where: {
+          id: id, // Replace with the actual ID of the model you want to find
+        },
+      });
+      return result;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+  delete: async (id) => {
+    try {
+      const result = await prisma.model.delete({
+        where: {
+          id: id,
+        },
+      });
+      return result;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+};

--- a/src/services/model.services.js
+++ b/src/services/model.services.js
@@ -4,7 +4,15 @@ import prisma from "../utils/prisma.js";
 export const modelServices = {
   get: async () => {
     try {
-      const models = await prisma.model.findMany();
+      const models = await prisma.model.findMany({
+        include: {
+          make: {
+            select:{
+              name: true
+            }
+          }
+        },
+      });
       return models;
     } catch (error) {
       throw new Error(error.message);

--- a/src/services/package.services.js
+++ b/src/services/package.services.js
@@ -1,0 +1,45 @@
+// package.services.js
+import prisma from "../utils/prisma.js";
+
+export const packageServices = {
+  get: async () => {
+    try {
+      const packages = await prisma.package.findMany();
+      return packages;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+  create: async (pkg) => {
+    try {
+      const result = await prisma.package.create({ data: pkg });
+      return result;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+  getPackageById: async (id) => {
+    try {
+      const result = await prisma.package.findUnique({
+        where: {
+          id: id, // Replace with the actual ID of the package you want to find
+        },
+      });
+      return result;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+  delete: async (id) => {
+    try {
+      const result = await prisma.package.delete({
+        where: {
+          id: id,
+        },
+      });
+      return result;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  },
+};

--- a/src/services/package.services.js
+++ b/src/services/package.services.js
@@ -4,7 +4,20 @@ import prisma from "../utils/prisma.js";
 export const packageServices = {
   get: async () => {
     try {
-      const packages = await prisma.package.findMany();
+      const packages = await prisma.package.findMany({
+        include: {
+          make: {
+            select: {
+              name: true,
+            },
+          },
+          model: {
+            select: {
+              name: true,
+            },
+          },
+        },
+      });
       return packages;
     } catch (error) {
       throw new Error(error.message);
@@ -18,12 +31,13 @@ export const packageServices = {
       throw new Error(error.message);
     }
   },
-  getPackageById: async (id) => {
+  filter: async (filter) => {
+    filter.id ? (filter.id = parseInt(filter.id)) : null;
+    filter.makeId ? (filter.makeId = parseInt(filter.makeId)) : null;
+    filter.modelId ? (filter.modelId = parseInt(filter.modelId)) : null;
     try {
-      const result = await prisma.package.findUnique({
-        where: {
-          id: id, // Replace with the actual ID of the package you want to find
-        },
+      const result = await prisma.package.findMany({
+        where: filter,
       });
       return result;
     } catch (error) {


### PR DESCRIPTION
Have succesfully divided the cars model to 4 models
Make model which specifies the make of vehicles (i.e the companies name)
Model model which specifies model of vehicle (i.e Porsche 911)
Package model which is specific configured pkg of a  model
then at last Car which references above three as foreign keys with additional information for the specific car being shown on the website
Also the backend filter has been added for the car endpoint to make it easier to filter info on admin and backend